### PR TITLE
Single conversion format e.g "$400". & Add a more relevant API error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,6 @@ And even shorter:
 
 [Download](./Currency%20Converter.alfredworkflow) and open the workflow file.
 
-## API/Rate Limits
-
-As the default API key is used by all users of this app, the amount of requests allowed per day may be depleted quickly. 
-
-Create and use your own personal API key (for free) to avoid the "`Error: Too many requests`" limit by:
-
-- Create an account at https://exchangerate-api.com
-- Create an API key at https://app.exchangerate-api.com/keys
-- Open the workflow and click "Open in Finder"
-- Open the file "currency.php" and replace the API key on line 5: `https://v6.exchangerate-api.com/v6/<YOUR-API-KEY>/pair/`
-
-
 ## Requirements
 
  - [Alfred 2.0](http://www.alfredapp.com/) or higher

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ And even shorter:
 
 [Download](./Currency%20Converter.alfredworkflow) and open the workflow file.
 
+## API/Rate Limits
+
+As the default API key is used by all users of this app, the amount of requests allowed per day may be depleted quickly. 
+
+Create and use your own personal API key (for free) to avoid the "`Error: Too many requests`" limit by:
+
+- Create an account at https://exchangerate-api.com
+- Create an API key at https://app.exchangerate-api.com/keys
+- Open the workflow and click "Open in Finder"
+- Open the file "currency.php" and replace the API key on line 5: `https://v6.exchangerate-api.com/v6/<YOUR-API-KEY>/pair/`
+
+
 ## Requirements
 
  - [Alfred 2.0](http://www.alfredapp.com/) or higher

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Note that `in` and `to` are interchangable. The default currency is GBP (can be 
 
 > c 30USD
 
+> c $30  
+
 Another shorthand is:
 
 > c 30$ to €


### PR DESCRIPTION
- Added support for "currency symbol first". Suggested in this issue https://github.com/sqren/alfred-currency/issues/16
- Better inform the user of the API's 429 "Too many requests" response. Mentioned here https://github.com/sqren/alfred-currency/issues/10

![image](https://user-images.githubusercontent.com/9389496/214705296-741cd569-151f-4133-ac13-6fe6854bd397.png)

<img width="686" alt="image" src="https://user-images.githubusercontent.com/9389496/214705380-5b4093bd-b443-42bd-980e-f7a8fc4fa2e9.png">

Happy to adjust the messaging for the 429 error. It would be nice to point the user towards setting the API key themselves. Perhaps via a field in the Alfred GUI?

